### PR TITLE
Initialize BLE central manager and set delegate in KBeaconsMgr

### DIFF
--- a/kbeaconlib2/Classes/KBeaconsMgr.swift
+++ b/kbeaconlib2/Classes/KBeaconsMgr.swift
@@ -77,6 +77,8 @@ let MAX_TIMER_OUT_INTERVAL = 0.3;
         mCBNtfBeacons = [String : KBeacon]()
         mCbAllBeacons = [String : KBeacon]()
         scanMinRssiFilter = -100
+        super.init()
+        cbBeaconMgr.delegate = self
     }
 
     //clear all beacon


### PR DESCRIPTION
Set cbBeaconMgr.delegate = self during initialization to ensure delegate methods are triggered.